### PR TITLE
update defaults comment

### DIFF
--- a/default.config
+++ b/default.config
@@ -18,5 +18,7 @@ GIT_GREP_OPTIONS="-I"
 
 # Specifying this directory allows you to run multi from any directory and search the same repositories
 # Example:
-#   BASE_DIR="~/src/"
+#   BASE_DIR="~/src"
+# OS X Example:
+#   BASE_DIR="/Users/<user>/src"
 BASE_DIR=""


### PR DESCRIPTION
Great tool @coryfklein! Had a couple issues getting it set up on OS X so figured I'd share my solution.
- The trailing `/` in the `~/src/` example ends up with `REPO_DIR="~/src//repo"`, which doesn't work.
- The `~/` expansion wasn't working for me (the `-d` test would fail), so I added an example with the full path as well.

Thanks for sharing!
