### PR TITLE
Change default installation location, added flags for changing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 `./install`
 
-This will install `multi` into `/usr/local/bin`. If your `$PATH` references that directory then you will be able to use `multi` from the command line immediately. Otherwise add `/usr/local/bin` to your `$PATH` first.
+This will install `multi` into `$HOME/.local/bin`. If your `$PATH` references that directory then you will be able to use `multi` from the command line immediately. Otherwise add `$HOME/.local/bin` to your `$PATH` first.
+
+Installing with flag `./install --global` will install `multi` into `usr/local/bin`, add `usr/local/bin` to your `$PATH` if it isn't already there.
 
 This will also install a `.multi` configuration file in your home directory.
 
@@ -36,3 +38,12 @@ phantomjs
 ====================================================
 test/ghostdriver-test/fixtures/common/macbeth.html:<A NAME=1.3.55>Are ye fantastical, or that indeed</A><br>
 test/ghostdriver-test/fixtures/common/macbeth.html:<A NAME=1.3.148>My thought, whose murder yet is but fantastical,</A><br>
+```
+
+# Uninstall
+
+`./uninstall`
+
+This will uninstall `multi` from `$HOME/.local/bin`, `/usr/local/bin`, `$HOME/.multi` and `/etc/multi`.
+
+Uninstalling with flag `./uninstall --exclude-local-config` will exclude `$HOME/.multi` from the uninstall.

--- a/install
+++ b/install
@@ -2,31 +2,81 @@
 
 # From http://stackoverflow.com/a/21188136/446554
 get_abs_filename() {
-    # $1 : relative filename
     echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 }
 
+MODE="$1"  # Usage: ./install [--global]
 INSTALL_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 DEFAULT_CONFIG_FILENAME="default.config"
-HOME_CONFIG_FILENAME="${HOME}/.multi"
-ETC_CONFIG_FILENAME="/etc/multi"
 EXECUTABLE="multi"
-INSTALLED_EXECUTABLE="/usr/local/bin/${EXECUTABLE}"
 EXECUTABLE_SOURCE=$(get_abs_filename "${INSTALL_SCRIPT_DIR}/${EXECUTABLE}")
 
-# Install the default config file in the user's home directory
-if [[ ! -f $HOME_CONFIG_FILENAME ]]; then
-    echo "Copying default config to $HOME_CONFIG_FILENAME"
-    cp "${INSTALL_SCRIPT_DIR}/$DEFAULT_CONFIG_FILENAME" "$HOME_CONFIG_FILENAME"
-fi
+if [[ "$MODE" == "--global" ]]; then
+    echo "Installing to /usr/local/bin"
+    echo ""
 
-# Install the default config file into /etc
-if [[ ! -f $ETC_CONFIG_FILENAME ]]; then
-    echo "Copying default config to $ETC_CONFIG_FILENAME"
-    sudo cp "${INSTALL_SCRIPT_DIR}/$DEFAULT_CONFIG_FILENAME" "$ETC_CONFIG_FILENAME"
-fi
+    HOME_CONFIG_FILENAME="${HOME}/.multi"
+    ETC_CONFIG_FILENAME="/etc/multi"
+    INSTALLED_EXECUTABLE="/usr/local/bin/${EXECUTABLE}"
 
-if [[ ! -L $INSTALLED_EXECUTABLE ]]; then
-    echo "Installing $EXECUTABLE to $INSTALLED_EXECUTABLE"
-    ln -s "$EXECUTABLE_SOURCE" "$INSTALLED_EXECUTABLE"
+    # Install the default config file in the user's home directory
+    if [[ ! -f $HOME_CONFIG_FILENAME ]]; then
+        echo "Copying default config to $HOME_CONFIG_FILENAME"
+        cp "${INSTALL_SCRIPT_DIR}/$DEFAULT_CONFIG_FILENAME" "$HOME_CONFIG_FILENAME"
+    elif [[ -f $HOME_CONFIG_FILENAME ]]; then
+        echo "WARN: $HOME_CONFIG_FILENAME already exists. Not overwriting."
+    fi
+
+    # Install the default config file into /etc
+    if [[ ! -f $ETC_CONFIG_FILENAME ]]; then
+        echo "Copying default config to $ETC_CONFIG_FILENAME"
+        sudo cp "${INSTALL_SCRIPT_DIR}/$DEFAULT_CONFIG_FILENAME" "$ETC_CONFIG_FILENAME"
+    elif [[ -f $ETC_CONFIG_FILENAME ]]; then
+        echo "WARN: $ETC_CONFIG_FILENAME already exists. Not overwriting."
+    fi
+
+    # Install executable in /usr/local/bin
+    if [[ ! -f $INSTALLED_EXECUTABLE ]]; then
+        echo "Installing $EXECUTABLE to $INSTALLED_EXECUTABLE"
+        sudo cp "$EXECUTABLE_SOURCE" "$INSTALLED_EXECUTABLE"
+        sudo chmod +x "$INSTALLED_EXECUTABLE"
+    elif [[ -f $INSTALLED_EXECUTABLE ]]; then
+        echo "WARN: $INSTALLED_EXECUTABLE already exists. Not overwriting."
+    fi
+
+    if [[ ":$PATH:" != *":/usr/local/bin:"* ]]; then
+        echo "WARNING: /usr/local/bin is not in your PATH."
+    fi
+
+else
+    echo "Installing locally to ~/.local/bin"
+    echo ""
+
+    HOME_CONFIG_FILENAME="${HOME}/.multi"
+    USER_BIN="${HOME}/.local/bin"
+    INSTALLED_EXECUTABLE="${USER_BIN}/${EXECUTABLE}"
+
+    # Create ~/.local/bin if it doesn't exist
+    mkdir -p "$USER_BIN"
+
+    # Install the default config file in the user's home directory
+    if [[ ! -f $HOME_CONFIG_FILENAME ]]; then
+        echo "Copying default config to $HOME_CONFIG_FILENAME"
+        cp "${INSTALL_SCRIPT_DIR}/$DEFAULT_CONFIG_FILENAME" "$HOME_CONFIG_FILENAME"
+    elif [[ -f $HOME_CONFIG_FILENAME ]]; then
+        echo "WARN: $HOME_CONFIG_FILENAME already exists. Not overwriting."
+    fi
+
+    # Install executable in ~/.local/bin
+    if [[ ! -f $INSTALLED_EXECUTABLE ]]; then
+        echo "Installing $EXECUTABLE to $INSTALLED_EXECUTABLE"
+        cp "$EXECUTABLE_SOURCE" "$INSTALLED_EXECUTABLE"
+        chmod +x "$INSTALLED_EXECUTABLE"
+    elif [[ -f $INSTALLED_EXECUTABLE ]]; then
+        echo "WARN: $INSTALLED_EXECUTABLE already exists. Not overwriting."
+    fi
+
+    if [[ ":$PATH:" != *":$USER_BIN:"* ]]; then
+        echo "WARNING: $USER_BIN is not in your PATH."
+    fi
 fi

--- a/multi
+++ b/multi
@@ -23,18 +23,19 @@ if [[ -z "$REPOS" ]]; then
 fi
 
 if [[ -z "$BASE_DIR" ]]; then
-  BASE_DIR=$(pwd)
+    BASE_DIR=$(pwd)
 else
-  BASE_DIR="${BASE_DIR/#\~/$HOME}"
+    BASE_DIR="${BASE_DIR/#\~/$HOME}"
 fi
 
 for REPO in $REPOS; do
     REPO_DIR="${BASE_DIR}/${REPO}"
     if [[ -d "$REPO_DIR" ]]; then
-        cd $REPO_DIR
-        echo $REPO
+        cd "$REPO_DIR"
+        echo ""
+        echo "$REPO"
         echo "===================================================="
         GIT_PAGER='' git grep $GIT_GREP_OPTIONS "$@"
-        cd $base_path
+        cd "$BASE_DIR"
     fi
 done

--- a/uninstall
+++ b/uninstall
@@ -3,21 +3,39 @@
 HOME_CONFIG_FILENAME="${HOME}/.multi"
 ETC_CONFIG_FILENAME="/etc/multi"
 EXECUTABLE="multi"
-INSTALLED_EXECUTABLE="/usr/local/bin/${EXECUTABLE}"
+USER_BIN="${HOME}/.local/bin"
+LOCAL_EXECUTABLE="${USER_BIN}/${EXECUTABLE}"
+SYSTEM_EXECUTABLE="/usr/local/bin/${EXECUTABLE}"
+
+EXCLUDE_CONFIG="false"
+
+if [[ "$1" == "--exclude-local-config" ]]; then
+    EXCLUDE_CONFIG="true"
+    shift
+fi
 
 # Remove the default config file from the user's home directory
-if [[ -f $HOME_CONFIG_FILENAME ]]; then
-    echo "Removing default config from $HOME_CONFIG_FILENAME"
+if [[ "$EXCLUDE_CONFIG" != "true" && -f $HOME_CONFIG_FILENAME ]]; then
+    echo "Removing user config: $HOME_CONFIG_FILENAME"
     rm "$HOME_CONFIG_FILENAME"
+elif [[ "$EXCLUDE_CONFIG" == "true" ]]; then
+    echo "WARN: Excluding $HOME_CONFIG_FILENAME from uninstall..."
+fi
+
+# Remove user's local executable
+if [[ -f $LOCAL_EXECUTABLE ]]; then
+    echo "Removing local executable: $LOCAL_EXECUTABLE"
+    rm "$LOCAL_EXECUTABLE"
 fi
 
 # Remove the default config file from /etc
 if [[ -f $ETC_CONFIG_FILENAME ]]; then
-    echo "Removing default config from $ETC_CONFIG_FILENAME"
+    echo "Removing system config: $ETC_CONFIG_FILENAME"
     sudo rm "$ETC_CONFIG_FILENAME"
 fi
 
-if [[ -L $INSTALLED_EXECUTABLE ]]; then
-    echo "Removing $EXECUTABLE from $INSTALLED_EXECUTABLE"
-    rm "$INSTALLED_EXECUTABLE"
+# Remove system executable
+if [[ -f $SYSTEM_EXECUTABLE ]]; then
+    echo "Removing system executable: $SYSTEM_EXECUTABLE"
+    sudo rm "$SYSTEM_EXECUTABLE"
 fi


### PR DESCRIPTION
**Changes:**
- By default `install` script will install to `$HOME/.local/bin` & `$HOME/.multi`
  - Avoids the need for sudo, doesn't affect other users
- Added `--global` flag for still installing to the previous locations
- Copying script to bin instead of symlinking, to remove need for keeping repo directory
- Make printed output from `multi` script more readable
- Allow excluding local config from uninstall with flag `--exclude-local-config`
- Updated README to match changes
